### PR TITLE
master introduce custom taxonomies as topics

### DIFF
--- a/includes/class-xmlsitemapfeed-admin.php
+++ b/includes/class-xmlsitemapfeed-admin.php
@@ -654,15 +654,40 @@ jQuery( document ).ready( function() {
     	// keywords
 		$keywords = !empty($options['keywords']) ? $options['keywords'] : array();
 		$keywords_from = !empty($keywords['from']) ? $keywords['from'] : '';
+		$default_taxonomies = [
+			'category' => translate('Categories'),
+			'post_tag' => translate('Tags')
+		];
+
+		$custom_taxonomies_raw = !empty($keywords['custom_taxonomies'])
+			? explode("\n", $keywords['custom_taxonomies'])
+			: array();
+
+		$custom_taxonomies = array_map(function ($raw_taxonomy) {
+			$taxonomy = explode('|', $raw_taxonomy);
+			return array(trim($taxonomy[0]) => trim($taxonomy[1]));
+		}, $custom_taxonomies_raw);
+
+		$taxonomies = count($custom_taxonomies) > 0
+			? array_merge($default_taxonomies, call_user_func_array('array_merge', $custom_taxonomies))
+			: $default_taxonomies;
+		$taxonomy_options = '';
+
+		foreach($taxonomies as $id => $label) {
+			$taxonomy_options .= '<option value="'.$id.'" '.selected( $id == $keywords_from, true, false).'>'.$label.'</option>';
+		}
+
 		echo '
 		<fieldset id="xmlsf_news_keywords"><legend class="screen-reader-text">&lt;keywords&gt;</legend>
 			'.sprintf(__('The %s tag is used to help classify the articles you submit to Google News by <strong>topic</strong>.','xml-sitemap-feed'),'<strong>&lt;keywords&gt;</strong>').'
 			<ul>
 			<li><label>'.sprintf(__('Use %s for topics.','xml-sitemap-feed'),' <select name="'.$prefix.'news_tags[keywords][from]" id="xmlsf_news_tags_keywords_from">
-						<option value="">'.translate('None').'</option>
-						<option value="category" '.selected( "category" == $keywords_from, true, false).'>'.translate('Categories').'</option>
-						<option value="post_tag" '.selected( "post_tag" == $keywords_from, true, false).'>'.translate('Tags').'</option>
-			</select>').'</label></li>';
+						<option value="">'.translate('None').'</option>' . $taxonomy_options . '
+			</select>').'</label></li>';echo '
+			<li><label>'.__('Custom taxonomies:','xml-sitemap-feed').' <br><textarea rows="3" cols="40" name="'.$prefix.'news_tags[keywords][custom_taxonomies]" placeholder="custom_key|Custom label" id="xmlsf_news_tags_keywords_custom_taxonomies">';
+			echo !empty($keywords['custom_taxonomies']) ? $keywords['custom_taxonomies'] : '';
+			echo '</textarea></label> <p class="description">'.__('Provide key name and label for a custom taxonomy you\'d like to add into "Topics" field above. Use pipe sign to separate taxonomy key and label. The custom taxonomies will be available to choose after saving changes.'.
+				'Put each custom taxonomy in a new line.','xml-sitemap-feed').'<br></p></li>';
 		if ("category" != $keywords_from) {
 			echo '
 			<li><label>'.__('Default topic(s):','xml-sitemap-feed').' <input type="text" name="'.$prefix.'news_tags[keywords][default]" id="xmlsf_news_tags_keywords_default" value="';


### PR DESCRIPTION
This PR add a possibility to define custom taxonomies as a source of tag keywords (`Topics`).

**How does it work?**
There is a new form field introduced to a user: `Custom taxonomies`.
![screen shot 2017-12-08 at 2 01 38 pm](https://user-images.githubusercontent.com/3687215/33749335-48d1ac5c-dc21-11e7-8885-38fbac41fc06.png)

If no value is provided there, the default taxonomies are displayed.
![screen shot 2017-12-08 at 2 01 45 pm](https://user-images.githubusercontent.com/3687215/33749345-5e47f28a-dc21-11e7-9c2f-accb80ab11c0.png)

The user can provide their own taxonomies, which will extend the available `Topics` dropdown. All they need to do is to type taxonomies' data into `Custom taxonomies` field:
```
custom_taxonomy_key|The label
random_key|The label 2
other_key|The label 3
```

As a result, the user can select as a `Topic` any taxonomy they need.
![screen shot 2017-12-08 at 2 02 41 pm](https://user-images.githubusercontent.com/3687215/33749418-c6b3cf92-dc21-11e7-94be-07bd9409343f.png)
