### PR TITLE
Fix performance issue with `set_defaults`

### DIFF
--- a/includes/class-xmlsitemapfeed.php
+++ b/includes/class-xmlsitemapfeed.php
@@ -213,7 +213,14 @@ class XMLSitemapFeed {
 		}
 
 		if ( isset($this->defaults['post_types']['post']) ) {
-			if (wp_count_posts('post')->publish > 500) {
+			$post_count = get_transient('xmlsf_post_count');
+
+			if (!is_object($post_count)) {
+				$post_count = wp_count_posts('post');
+				set_transient('xmlsf_post_count', $post_count, DAY_IN_SECONDS);
+			}
+			
+			if ($post_count->publish > 500) {
 				$this->defaults['post_types']['post']['archive'] = 'yearly';
 			}
 			$this->defaults['post_types']['post']['priority'] = '0.7';


### PR DESCRIPTION
We're currently running into performance issues with the plugin on a very large WordPress site with 400k posts. The performance issue comes from the call to `wp_count_posts` in the `set_defaults` method of the `XMLSitemapFeed` class. On our site, `wp_count_posts` causes WordPress to perform a non-cacheable query that takes about 1s.

The solution in this PR is to use a transient to cache the result of `wp_count_posts` for a day. This prevents this expensive query from happening on every page load. I'm open to another solution if you don't like this one though. 😃 