### PR TITLE
Fix some undefined index warnings

### DIFF
--- a/includes/class-xmlsitemapfeed.php
+++ b/includes/class-xmlsitemapfeed.php
@@ -1528,7 +1528,7 @@ class XMLSitemapFeed {
 								continue;
 							}
 							// ping !
-							if ( $this->ping( add_query_arg( $data['req'], urlencode(trailingslashit(get_bloginfo('url')).$sitemaps['sitemap']), $data['uri'] ) ) ) {
+							if ( isset($data['req'], $data['uri']) && $this->ping( add_query_arg( $data['req'], urlencode(trailingslashit(get_bloginfo('url')).$sitemaps['sitemap']), $data['uri'] ) ) ) {
 								$to_ping[$se]['pong'][$sitemaps['sitemap']] = time();
 								$update = true;
 							}


### PR DESCRIPTION
We're getting some warnings in our error logs related to this `if` condition. Added an `isset` check first to make sure the `data` array has the required keys before doing the ping.