### PR TITLE
Add hooks for XML namespaces

### DIFF
--- a/views/feed-sitemap-custom.php
+++ b/views/feed-sitemap-custom.php
@@ -13,7 +13,7 @@ echo '<?xml version="1.0" encoding="' . get_bloginfo('charset') . '"?>
 '; ?>
 <?php xmlsf_generator(); ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-	<?php do_action('xmlsf_urlset_custom'); ?>
+<?php do_action('xmlsf_urlset_custom'); ?>
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
 		http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">

--- a/views/feed-sitemap-custom.php
+++ b/views/feed-sitemap-custom.php
@@ -13,6 +13,7 @@ echo '<?xml version="1.0" encoding="' . get_bloginfo('charset') . '"?>
 '; ?>
 <?php xmlsf_generator(); ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+	<?php do_action('xmlsf_urlset_custom'); ?>
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
 		http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">

--- a/views/feed-sitemap-custom.php
+++ b/views/feed-sitemap-custom.php
@@ -13,7 +13,7 @@ echo '<?xml version="1.0" encoding="' . get_bloginfo('charset') . '"?>
 '; ?>
 <?php xmlsf_generator(); ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-<?php do_action('xmlsf_urlset_custom'); ?>
+<?php do_action('xmlsf_urlset', 'custom'); ?>
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
 		http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">

--- a/views/feed-sitemap-home.php
+++ b/views/feed-sitemap-home.php
@@ -13,6 +13,7 @@ echo '<?xml version="1.0" encoding="' . get_bloginfo('charset') . '"?>
 '; ?>
 <?php xmlsf_generator(); ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+	<?php do_action('xmlsf_urlset_home'); ?>
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
 		http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">

--- a/views/feed-sitemap-home.php
+++ b/views/feed-sitemap-home.php
@@ -13,7 +13,7 @@ echo '<?xml version="1.0" encoding="' . get_bloginfo('charset') . '"?>
 '; ?>
 <?php xmlsf_generator(); ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-	<?php do_action('xmlsf_urlset_home'); ?>
+<?php do_action('xmlsf_urlset_home'); ?>
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
 		http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">

--- a/views/feed-sitemap-home.php
+++ b/views/feed-sitemap-home.php
@@ -13,7 +13,7 @@ echo '<?xml version="1.0" encoding="' . get_bloginfo('charset') . '"?>
 '; ?>
 <?php xmlsf_generator(); ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-<?php do_action('xmlsf_urlset_home'); ?>
+<?php do_action('xmlsf_urlset', 'home'); ?>
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
 		http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">

--- a/views/feed-sitemap-news.php
+++ b/views/feed-sitemap-news.php
@@ -15,7 +15,7 @@ echo '<?xml version="1.0" encoding="' . get_bloginfo('charset') . '"?>
 '; ?>
 <?php xmlsf_generator(); ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-<?php do_action('xmlsf_urlset_news'); ?>
+<?php do_action('xmlsf_urlset,', 'news'); ?>
 	xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
 <?php
 

--- a/views/feed-sitemap-news.php
+++ b/views/feed-sitemap-news.php
@@ -15,6 +15,7 @@ echo '<?xml version="1.0" encoding="' . get_bloginfo('charset') . '"?>
 '; ?>
 <?php xmlsf_generator(); ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+	<?php do_action('xmlsf_urlset_news'); ?>
 	xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
 <?php
 

--- a/views/feed-sitemap-news.php
+++ b/views/feed-sitemap-news.php
@@ -15,7 +15,7 @@ echo '<?xml version="1.0" encoding="' . get_bloginfo('charset') . '"?>
 '; ?>
 <?php xmlsf_generator(); ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-<?php do_action('xmlsf_urlset,', 'news'); ?>
+<?php do_action('xmlsf_urlset', 'news'); ?>
 	xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
 <?php
 

--- a/views/feed-sitemap-news.php
+++ b/views/feed-sitemap-news.php
@@ -15,7 +15,7 @@ echo '<?xml version="1.0" encoding="' . get_bloginfo('charset') . '"?>
 '; ?>
 <?php xmlsf_generator(); ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-	<?php do_action('xmlsf_urlset_news'); ?>
+<?php do_action('xmlsf_urlset_news'); ?>
 	xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
 <?php
 

--- a/views/feed-sitemap-post_type.php
+++ b/views/feed-sitemap-post_type.php
@@ -27,6 +27,7 @@ echo '<?xml version="1.0" encoding="' . get_bloginfo('charset') . '"?>
 '; ?>
 <?php xmlsf_generator(); ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+<?php do_action('xmlsf_urlset_post_type'); ?>
 <?php echo $image_xmlns; ?>
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9

--- a/views/feed-sitemap-post_type.php
+++ b/views/feed-sitemap-post_type.php
@@ -27,7 +27,7 @@ echo '<?xml version="1.0" encoding="' . get_bloginfo('charset') . '"?>
 '; ?>
 <?php xmlsf_generator(); ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-<?php do_action('xmlsf_urlset_post_type'); ?>
+<?php do_action('xmlsf_urlset', 'post_type'); ?>
 <?php echo $image_xmlns; ?>
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9

--- a/views/feed-sitemap-taxonomy.php
+++ b/views/feed-sitemap-taxonomy.php
@@ -13,7 +13,7 @@ echo '<?xml version="1.0" encoding="' . get_bloginfo('charset') . '"?>
 '; ?>
 <?php xmlsf_generator(); ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-<?php do_action('xmlsf_urlset_taxonomy'); ?>
+<?php do_action('xmlsf_urlset', 'taxonomy'); ?>
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
 		http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">

--- a/views/feed-sitemap-taxonomy.php
+++ b/views/feed-sitemap-taxonomy.php
@@ -13,6 +13,7 @@ echo '<?xml version="1.0" encoding="' . get_bloginfo('charset') . '"?>
 '; ?>
 <?php xmlsf_generator(); ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+	<?php do_action('xmlsf_urlset_taxonomy'); ?>
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
 		http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">

--- a/views/feed-sitemap-taxonomy.php
+++ b/views/feed-sitemap-taxonomy.php
@@ -13,7 +13,7 @@ echo '<?xml version="1.0" encoding="' . get_bloginfo('charset') . '"?>
 '; ?>
 <?php xmlsf_generator(); ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-	<?php do_action('xmlsf_urlset_taxonomy'); ?>
+<?php do_action('xmlsf_urlset_taxonomy'); ?>
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
 		http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">

--- a/views/feed-sitemap.php
+++ b/views/feed-sitemap.php
@@ -13,6 +13,7 @@ echo '<?xml version="1.0" encoding="' . get_bloginfo('charset') . '"?>
 '; ?>
 <?php xmlsf_generator(); ?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+	<?php do_action('xmlsf_urlset_sitemap'); ?>
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
 		http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd">

--- a/views/feed-sitemap.php
+++ b/views/feed-sitemap.php
@@ -13,7 +13,7 @@ echo '<?xml version="1.0" encoding="' . get_bloginfo('charset') . '"?>
 '; ?>
 <?php xmlsf_generator(); ?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-<?php do_action('xmlsf_urlset_sitemap'); ?>
+<?php do_action('xmlsf_urlset', 'sitemap'); ?>
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
 		http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd">

--- a/views/feed-sitemap.php
+++ b/views/feed-sitemap.php
@@ -13,7 +13,7 @@ echo '<?xml version="1.0" encoding="' . get_bloginfo('charset') . '"?>
 '; ?>
 <?php xmlsf_generator(); ?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-	<?php do_action('xmlsf_urlset_sitemap'); ?>
+<?php do_action('xmlsf_urlset_sitemap'); ?>
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
 		http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd">

--- a/xml-sitemap.php
+++ b/xml-sitemap.php
@@ -3,7 +3,7 @@
 Plugin Name: XML Sitemap & Google News
 Plugin URI: http://status301.net/wordpress-plugins/xml-sitemap-feed/
 Description: Feed the  hungry spiders in compliance with the XML Sitemap and Google News protocols. Happy with the results? Please leave me a <strong><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=ravanhagen%40gmail%2ecom&item_name=XML%20Sitemap%20Feed">tip</a></strong> for continued development and support. Thanks :)
-Version: 5.2.6
+Version: 5.2.7
 Text Domain: xml-sitemap-feed
 Requires at least: 4.6
 Requires PHP: 5.4


### PR DESCRIPTION
I am working on a plugin that adds [multilingual sitemap links](https://support.google.com/webmasters/answer/189077#sitemap) to the sitemaps generated by this plugin.

When doing this, you need to add an XML namespace to generate valid XML, but there is no hook for this. I have added hooks that are required for this to work properly.

Here is an example of the hook in use. This is using [Polylang](https://wordpress.org/plugins/polylang/) for multilingual support to add the xhtml namespace and print the alternative languages the post is available in to the sitemap.

```php
// This is an example of one of the new hooks!
add_action('xmlsf_urlset', function ($type) {
	if($type === 'post_type') {
    echo 'xmlns:xhtml="http://www.w3.org/1999/xhtml"' . PHP_EOL;
	}
});

// This hooks already exists, thanks!
add_action('xmlsf_tags_after', function () { // xmlsf_tags_after
  $languages = pll_languages_list();
  foreach ($languages as $language) {
    $id              = get_the_ID();
    $translated_post = pll_get_post($id, $language);

    if ($translated_post && $translated_post !== $id) {
      ?>
	<xhtml:link rel="alternate" hreflang="<?php echo $language; ?>" href="<?php echo get_the_permalink(pll_get_post($id, $language)); ?>"/>
      <?php
    }
  }
});
```