### PR TITLE
Google News: better title filters, introduce real xmlsf_news_tags_after

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+  "name": "ravanh/xml-sitemap-feed",
+  "description": "XML and Google News Sitemaps for WordPress to feed the hungry spiders. Multisite, WP Super Cache, Polylang and WPML compatible.",
+  "type": "wordpress-plugin",
+  "license": "GPL-2.0-or-later",
+  "version": "5.2.8",
+  "authors": [
+    {
+      "name": "Rolf Allard van Hagen"
+    }
+  ]
+}

--- a/views/feed-sitemap-news.php
+++ b/views/feed-sitemap-news.php
@@ -15,62 +15,62 @@ echo '<?xml version="1.0" encoding="' . get_bloginfo('charset') . '"?>
 '; ?>
 <?php xmlsf_generator(); ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-<?php do_action('xmlsf_urlset', 'news'); ?>
-	xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
-<?php
-
-// set empty news sitemap flag
-$have_posts = false;
-
-// loop away!
-if ( have_posts() ) :
+  <?php do_action('xmlsf_urlset', 'news'); ?>
+        xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
+  <?php
+  
+  // set empty news sitemap flag
+  $have_posts = false;
+  
+  // loop away!
+  if ( have_posts() ) :
     while ( have_posts() ) :
-		the_post();
-
-		// check if we are not dealing with an external URL :: Thanks to Francois Deschenes :)
-		// or if post meta says "exclude me please"
-		if ( apply_filters(
-			 	'xmlsf_news_excluded',
-			 	get_post_meta( $post->ID, '_xmlsf_news_exclude', true ),
-			 	$post->ID
-			 ) || !xmlsf_is_allowed_domain( get_permalink() ) )
-			continue;
-
-		$have_posts = true;
-		?>
-	<url>
-		<loc><?php echo esc_url( get_permalink() ); ?></loc>
-		<news:news>
-			<news:publication>
-				<news:name><?php
-					if( !empty($options['name']) )
-						echo apply_filters( 'xmlsf_news_publication_name', $options['name'] );
-					elseif(defined('XMLSF_GOOGLE_NEWS_NAME'))
-						echo apply_filters( 'xmlsf_news_publication_name', XMLSF_GOOGLE_NEWS_NAME );
-					else
-						echo apply_filters( 'xmlsf_news_publication_name', get_bloginfo('name') ); ?></news:name>
-				<news:language><?php echo xmlsf_get_language( $post->ID ); ?></news:language>
-			</news:publication>
-			<news:publication_date><?php echo mysql2date( DATE_W3C, $post->post_date ); ?></news:publication_date>
-			<news:title><?php echo apply_filters( 'xmlsf_news_title', get_the_title() ); ?></news:title>
-			<news:keywords><?php echo implode( ', ', apply_filters( 'xmlsf_news_keywords', array() ) ); ?></news:keywords>
-			<news:stock_tickers><?php echo implode( ', ', apply_filters( 'xmlsf_news_stock_tickers', array() ) ); ?></news:stock_tickers>
-<?php do_action( 'xmlsf_news_tags_before' ); ?>
-		</news:news>
-    <?php do_action( 'xmlsf_news_tags_after' ); ?>
-  </url>
-<?php
-			do_action( 'xmlsf_news_url_after' );
+      the_post();
+      
+      // check if we are not dealing with an external URL :: Thanks to Francois Deschenes :)
+      // or if post meta says "exclude me please"
+      if ( apply_filters(
+             'xmlsf_news_excluded',
+             get_post_meta( $post->ID, '_xmlsf_news_exclude', true ),
+             $post->ID
+           ) || !xmlsf_is_allowed_domain( get_permalink() ) )
+        continue;
+      
+      $have_posts = true;
+      ?>
+      <url>
+        <loc><?php echo esc_url( get_permalink() ); ?></loc>
+        <news:news>
+          <news:publication>
+            <news:name><?php
+              if( !empty($options['name']) )
+                echo apply_filters( 'xmlsf_news_publication_name', $options['name'] );
+              elseif(defined('XMLSF_GOOGLE_NEWS_NAME'))
+                echo apply_filters( 'xmlsf_news_publication_name', XMLSF_GOOGLE_NEWS_NAME );
+              else
+                echo apply_filters( 'xmlsf_news_publication_name', get_bloginfo('name') ); ?></news:name>
+            <news:language><?php echo xmlsf_get_language( $post->ID ); ?></news:language>
+          </news:publication>
+          <news:publication_date><?php echo mysql2date( DATE_W3C, $post->post_date ); ?></news:publication_date>
+          <news:title><?php echo apply_filters( 'xmlsf_news_title', get_the_title() ); ?></news:title>
+          <news:keywords><?php echo implode( ', ', apply_filters( 'xmlsf_news_keywords', array() ) ); ?></news:keywords>
+          <news:stock_tickers><?php echo implode( ', ', apply_filters( 'xmlsf_news_stock_tickers', array() ) ); ?></news:stock_tickers>
+          <?php do_action( 'xmlsf_news_tags_inner' ); ?>
+        </news:news>
+        <?php do_action( 'xmlsf_news_tags_after' ); ?>
+      </url>
+      <?php
+      do_action( 'xmlsf_news_url_after' );
     endwhile;
-endif;
-
-if ( !$have_posts ) :
-	// No posts done? Then do at least the homepage to prevent error message in GWT.
-	?>
-	<url>
-		<loc><?php echo esc_url( home_url() ); ?></loc>
-	</url>
-<?php
-endif;
-?></urlset>
+  endif;
+  
+  if ( !$have_posts ) :
+    // No posts done? Then do at least the homepage to prevent error message in GWT.
+    ?>
+    <url>
+      <loc><?php echo esc_url( home_url() ); ?></loc>
+    </url>
+  <?php
+  endif;
+  ?></urlset>
 <?php xmlsf_usage(); ?>

--- a/views/feed-sitemap-news.php
+++ b/views/feed-sitemap-news.php
@@ -44,15 +44,15 @@ if ( have_posts() ) :
 			<news:publication>
 				<news:name><?php
 					if( !empty($options['name']) )
-						echo apply_filters( 'the_title_xmlsitemap', $options['name'] );
+						echo apply_filters( 'xmlsf_news_publication_name', $options['name'] );
 					elseif(defined('XMLSF_GOOGLE_NEWS_NAME'))
-						echo apply_filters( 'the_title_xmlsitemap', XMLSF_GOOGLE_NEWS_NAME );
+						echo apply_filters( 'xmlsf_news_publication_name', XMLSF_GOOGLE_NEWS_NAME );
 					else
-						echo apply_filters( 'the_title_xmlsitemap', get_bloginfo('name') ); ?></news:name>
+						echo apply_filters( 'xmlsf_news_publication_name', get_bloginfo('name') ); ?></news:name>
 				<news:language><?php echo xmlsf_get_language( $post->ID ); ?></news:language>
 			</news:publication>
 			<news:publication_date><?php echo mysql2date( DATE_W3C, $post->post_date ); ?></news:publication_date>
-			<news:title><?php echo apply_filters( 'the_title_xmlsitemap', get_the_title() ); ?></news:title>
+			<news:title><?php echo apply_filters( 'xmlsf_news_title', get_the_title() ); ?></news:title>
 			<news:keywords><?php echo implode( ', ', apply_filters( 'xmlsf_news_keywords', array() ) ); ?></news:keywords>
 			<news:stock_tickers><?php echo implode( ', ', apply_filters( 'xmlsf_news_stock_tickers', array() ) ); ?></news:stock_tickers>
 <?php do_action( 'xmlsf_news_tags_after' ); ?>

--- a/views/feed-sitemap-news.php
+++ b/views/feed-sitemap-news.php
@@ -55,9 +55,10 @@ if ( have_posts() ) :
 			<news:title><?php echo apply_filters( 'xmlsf_news_title', get_the_title() ); ?></news:title>
 			<news:keywords><?php echo implode( ', ', apply_filters( 'xmlsf_news_keywords', array() ) ); ?></news:keywords>
 			<news:stock_tickers><?php echo implode( ', ', apply_filters( 'xmlsf_news_stock_tickers', array() ) ); ?></news:stock_tickers>
-<?php do_action( 'xmlsf_news_tags_after' ); ?>
+<?php do_action( 'xmlsf_news_tags_before' ); ?>
 		</news:news>
-	</url>
+    <?php do_action( 'xmlsf_news_tags_after' ); ?>
+  </url>
 <?php
 			do_action( 'xmlsf_news_url_after' );
     endwhile;


### PR DESCRIPTION
**Careful** This are necessary changes, but can break current code!

---

- Use different filters for publication:name and news:title

Surprisingly the same filter was used for the publication:name and the news:title. I changed this and renamed the filters in line with rest.

- introduce real xmlsf_news_tags_after

If you want to add `<image>` to the `<url>`, those have to be defined outside `<news>`. I introduced a proper action `xmlsf_news_tags_after` and renamed the old one to `xmlsf_news_tags_before`.

